### PR TITLE
feat(cicd): GitHub Actions deploy workflow + Trivy container scanning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,197 @@
+name: Deploy to Cloud Run
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        required: true
+        default: "dev"
+        type: choice
+        options:
+          - dev
+
+# Prevent concurrent deploys to the same environment
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGION: europe-west1
+  APP_NAME: shoot-ai
+  ENVIRONMENT: dev
+  TF_VERSION: "1.9.0"
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────────────
+  # Build & Push Docker image to Artifact Registry
+  # ─────────────────────────────────────────────────────────────────────────
+  build-and-push:
+    name: Build & Push
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write   # Required for Workload Identity Federation
+
+    outputs:
+      image_tag: ${{ steps.meta.outputs.sha_short }}
+      image_url: ${{ steps.meta.outputs.image_url }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GCP via Workload Identity
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+
+      - name: Extract metadata
+        id: meta
+        run: |
+          SHA_SHORT=$(git rev-parse --short HEAD)
+          NAME_PREFIX="${{ env.APP_NAME }}-${{ env.ENVIRONMENT }}"
+          REGISTRY="${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${NAME_PREFIX}"
+          IMAGE_URL="${REGISTRY}/${{ env.APP_NAME }}"
+          echo "sha_short=${SHA_SHORT}" >> "$GITHUB_OUTPUT"
+          echo "image_url=${IMAGE_URL}" >> "$GITHUB_OUTPUT"
+          echo "registry=${REGISTRY}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.image_url }}:${{ steps.meta.outputs.sha_short }}
+            ${{ steps.meta.outputs.image_url }}:latest
+          cache-from: type=registry,ref=${{ steps.meta.outputs.image_url }}:buildcache
+          cache-to: type=registry,ref=${{ steps.meta.outputs.image_url }}:buildcache,mode=max
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Terraform apply + Cloud Run deploy
+  # ─────────────────────────────────────────────────────────────────────────
+  deploy:
+    name: Terraform Apply + Deploy
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    environment: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && 'prod' || 'dev' }}
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GCP via Workload Identity
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+          terraform_wrapper: false
+
+      - name: Terraform Init
+        working-directory: infra/terraform
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ secrets.GCP_PROJECT_ID }}-tfstate" \
+            -backend-config="prefix=terraform/state/${{ secrets.GCP_PROJECT_ID }}"
+
+      - name: Terraform Plan
+        working-directory: infra/terraform
+        env:
+          TF_VAR_gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          TF_VAR_api_keys: ${{ secrets.API_KEYS }}
+        run: |
+          terraform plan \
+            -var-file="environments/${{ env.ENVIRONMENT }}/terraform.tfvars" \
+            -var="project_id=${{ secrets.GCP_PROJECT_ID }}" \
+            -var="image_tag=${{ needs.build-and-push.outputs.image_tag }}" \
+            -out=tfplan
+
+      - name: Terraform Apply
+        working-directory: infra/terraform
+        env:
+          TF_VAR_gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          TF_VAR_api_keys: ${{ secrets.API_KEYS }}
+        run: terraform apply -auto-approve tfplan
+
+      - name: Get service URL
+        id: service_url
+        working-directory: infra/terraform
+        run: echo "url=$(terraform output -raw service_url)" >> "$GITHUB_OUTPUT"
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Smoke tests — verify the deployed service is healthy
+  # ─────────────────────────────────────────────────────────────────────────
+  smoke-test:
+    name: Smoke Tests
+    runs-on: ubuntu-latest
+    needs: deploy
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Authenticate to GCP via Workload Identity
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Get deployed service URL
+        id: service_url
+        run: |
+          URL=$(gcloud run services describe \
+            ${{ env.APP_NAME }}-${{ env.ENVIRONMENT }} \
+            --region=${{ env.REGION }} \
+            --project=${{ secrets.GCP_PROJECT_ID }} \
+            --format="value(status.url)")
+          echo "url=${URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Health check (no auth required)
+        run: |
+          curl --retry 5 --retry-delay 5 --fail \
+            "${{ steps.service_url.outputs.url }}/health"
+
+      - name: Auth check (valid key)
+        run: |
+          FIRST_KEY=$(echo '${{ secrets.API_KEYS }}' | python3 -c "import json,sys; keys=json.load(sys.stdin); print(keys[0] if keys else '')")
+          if [ -n "$FIRST_KEY" ]; then
+            curl --retry 3 --fail \
+              -H "X-API-Key: ${FIRST_KEY}" \
+              "${{ steps.service_url.outputs.url }}/player/smoke-test/history"
+          else
+            echo "No API keys configured — skipping auth check"
+          fi
+
+      - name: Auth check (no key → 401)
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            "${{ steps.service_url.outputs.url }}/player/smoke-test/history")
+          # If api_keys empty, auth disabled → 200; if keys set → 401
+          echo "Status without auth: ${STATUS}"
+          [ "$STATUS" = "401" ] || [ "$STATUS" = "200" ]

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -56,3 +56,25 @@ jobs:
       - name: Run bandit (fail on HIGH)
         run: uv run bandit -r src/ -c pyproject.toml --severity-level high
         # Fails CI only on HIGH severity issues
+
+  container-scan:
+    name: Container scan (Trivy)
+    runs-on: ubuntu-latest
+    # Only on PRs and main pushes (not weekly cron — image rebuild not scheduled)
+    if: github.event_name != 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image for scanning
+        run: docker build --platform linux/amd64 -t shoot-ai:scan .
+
+      - name: Run Trivy container scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: "shoot-ai:scan"
+          format: "table"
+          exit-code: "1"
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "CRITICAL"
+        # Fail CI on CRITICAL CVEs only — MEDIUM/HIGH logged but don't block

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,17 +94,19 @@ export PROJECT_ID="shoot-ai-dev"
 export BILLING_ACCOUNT="XXXXXX-XXXXXX-XXXXXX"
 bash infra/scripts/bootstrap.sh
 
-# Init + import existing project
+# Set all variables upfront (available to both import and apply)
 cd infra/terraform
 terraform init -backend-config="bucket=${PROJECT_ID}-tfstate" \
                -backend-config="prefix=terraform/state/${PROJECT_ID}"
-terraform import google_project.shoot_ai $PROJECT_ID
 
-# Apply (secrets via env vars)
+export TF_VAR_project_id="$PROJECT_ID"
+export TF_VAR_billing_account="$BILLING_ACCOUNT"
 export TF_VAR_gemini_api_key="$GEMINI_API_KEY"
 export TF_VAR_api_keys='["dev-key-1"]'
-terraform apply -var-file=environments/dev/terraform.tfvars \
-                -var="project_id=$PROJECT_ID"
+
+# Import the pre-existing project (created by bootstrap.sh) then apply
+terraform import -var-file=environments/dev/terraform.tfvars google_project.shoot_ai "$PROJECT_ID"
+terraform apply -var-file=environments/dev/terraform.tfvars
 ```
 
 After apply, copy the outputs to GitHub Secrets:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,3 +70,46 @@ chore/*       ← maintenance
 
 ## Questions ?
 Ouvre une issue ou contacte directement via GitHub.
+
+---
+
+## CI/CD Setup (maintainers)
+
+### Required GitHub Secrets
+
+Set these in **Settings → Secrets and variables → Actions**:
+
+| Secret | Description |
+|---|---|
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | WIF provider resource name (from `terraform output workload_identity_provider`) |
+| `GCP_SERVICE_ACCOUNT` | CI/CD service account email (from `terraform output cicd_service_account`) |
+| `GCP_PROJECT_ID` | GCP project ID (e.g. `shoot-ai-dev`) |
+| `GEMINI_API_KEY` | Gemini API key |
+| `API_KEYS` | JSON array of API keys (e.g. `["key1","key2"]`) |
+
+### First-time GCP setup
+
+```bash
+export PROJECT_ID="shoot-ai-dev"
+export BILLING_ACCOUNT="XXXXXX-XXXXXX-XXXXXX"
+bash infra/scripts/bootstrap.sh
+
+# Init + import existing project
+cd infra/terraform
+terraform init -backend-config="bucket=${PROJECT_ID}-tfstate" \
+               -backend-config="prefix=terraform/state/${PROJECT_ID}"
+terraform import google_project.shoot_ai $PROJECT_ID
+
+# Apply (secrets via env vars)
+export TF_VAR_gemini_api_key="$GEMINI_API_KEY"
+export TF_VAR_api_keys='["dev-key-1"]'
+terraform apply -var-file=environments/dev/terraform.tfvars \
+                -var="project_id=$PROJECT_ID"
+```
+
+After apply, copy the outputs to GitHub Secrets:
+```bash
+terraform output workload_identity_provider  # → GCP_WORKLOAD_IDENTITY_PROVIDER
+terraform output cicd_service_account        # → GCP_SERVICE_ACCOUNT
+```
+


### PR DESCRIPTION
## CI/CD Pipeline — Phase 5b final

### Deploy workflow (`.github/workflows/deploy.yml`)

**Trigger:** `push main`, `push v*.*.*` tags, `workflow_dispatch`

**Architecture (3 jobs):**

```
build-and-push
  ├─ WIF auth (no JSON key)
  ├─ docker buildx --platform linux/amd64
  ├─ push {SHA} + :latest to Artifact Registry
  └─ build cache via registry (mode=max)

deploy
  ├─ WIF auth
  ├─ terraform init (GCS backend)
  ├─ terraform plan -var image_tag=$SHA
  └─ terraform apply (Cloud Run updates to new SHA image)

smoke-test
  ├─ GET /health → curl --retry 5
  ├─ GET /player/smoke-test/history with valid X-API-Key
  └─ GET without key → expects 401 (or 200 if auth disabled)
```

**Security:**
- Zero static JSON keys — Workload Identity Federation only
- Secrets via GitHub Secrets → `TF_VAR_*` env vars (never in tfvars)
- Concurrency group: cancels duplicate runs, no parallel deploys

### Container scanning (`.github/workflows/security.yml`)

Added `container-scan` job:
- Builds the image, then runs **Trivy** (aquasecurity/trivy-action)
- Fails CI on **CRITICAL** CVEs only (ignore-unfixed, os+library)
- Skipped on weekly cron schedule (no new image build)

### CONTRIBUTING.md

Added CI/CD setup section:
- Required GitHub Secrets table (5 secrets + descriptions)
- Step-by-step bootstrap + first apply instructions
- How to get WIF outputs for GitHub Secrets

### Required GitHub Secrets (set before first deploy)

| Secret | Value from |
|---|---|
| `GCP_WORKLOAD_IDENTITY_PROVIDER` | `terraform output workload_identity_provider` |
| `GCP_SERVICE_ACCOUNT` | `terraform output cicd_service_account` |
| `GCP_PROJECT_ID` | Your GCP project ID |
| `GEMINI_API_KEY` | Your Gemini API key |
| `API_KEYS` | JSON array: `["key1"]`