### PR TITLE
fix(ci): harden Trivy container scan

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -60,21 +60,46 @@ jobs:
   container-scan:
     name: Container scan (Trivy)
     runs-on: ubuntu-latest
-    # Only on PRs and main pushes (not weekly cron — image rebuild not scheduled)
-    if: github.event_name != 'schedule'
+    # Runs on push, PR, and weekly cron — the cron is exactly when new CVEs are
+    # found in unchanged images (OS base, transitive lib updates upstream).
+    permissions:
+      contents: read
+      security-events: write # Upload SARIF to GitHub Security tab
     steps:
       - uses: actions/checkout@v4
 
       - name: Build image for scanning
         run: docker build --platform linux/amd64 -t shoot-ai:scan .
 
-      - name: Run Trivy container scan
-        uses: aquasecurity/trivy-action@master
+      # Step 1 — fail the job on HIGH/CRITICAL CVEs (gating). MEDIUM is reported
+      # only via SARIF upload below so the developer sees them in the Security
+      # tab without blocking CI on noisy lower-severity findings.
+      - name: Trivy container scan (gating — fail on HIGH/CRITICAL)
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           image-ref: "shoot-ai:scan"
           format: "table"
           exit-code: "1"
           ignore-unfixed: true
           vuln-type: "os,library"
-          severity: "CRITICAL"
-        # Fail CI on CRITICAL CVEs only — MEDIUM/HIGH logged but don't block
+          severity: "HIGH,CRITICAL"
+
+      # Step 2 — always emit SARIF (even when the gating step failed) so every
+      # finding lands in the GitHub Security tab for triage history.
+      - name: Trivy container scan (SARIF report)
+        if: always()
+        uses: aquasecurity/trivy-action@0.36.0
+        with:
+          image-ref: "shoot-ai:scan"
+          format: "sarif"
+          output: "trivy-results.sarif"
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "MEDIUM,HIGH,CRITICAL"
+
+      - name: Upload Trivy SARIF to GitHub Security
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "trivy-results.sarif"
+          category: "trivy-container"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -75,7 +75,7 @@ jobs:
       # only via SARIF upload below so the developer sees them in the Security
       # tab without blocking CI on noisy lower-severity findings.
       - name: Trivy container scan (gating — fail on HIGH/CRITICAL)
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: "shoot-ai:scan"
           format: "table"
@@ -88,7 +88,7 @@ jobs:
       # finding lands in the GitHub Security tab for triage history.
       - name: Trivy container scan (SARIF report)
         if: always()
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: "shoot-ai:scan"
           format: "sarif"


### PR DESCRIPTION
## Contexte

L'audit a flaggé 4 misconfigurations dans le job `container-scan` de `.github/workflows/security.yml` (PR #30, mergée le 2026-05-09) — chacune réduit la valeur du scan Trivy :

| # | Problème | Impact |
|---|----------|--------|
| 1 | `aquasecurity/trivy-action@master` | Tag flottant — comportement non-déterministe entre runs, risque de breaking change silencieux |
| 2 | `if: github.event_name != 'schedule'` | Trivy ne tourne pas sur le cron hebdo — alors que c'est précisément ce moment qui détecte les nouvelles CVE sur une image inchangée (OS base, transitive deps upstream) |
| 3 | `severity: "CRITICAL"` | Rate les HIGH (typiquement OS CVEs activement exploitées) |
| 4 | Pas de SARIF upload | Aucune visibilité dans l'onglet Security de GitHub, pas d'historique de triage |

## Changements

- **Pin** `aquasecurity/trivy-action@0.36.0` (latest stable au 2026-04-22)
- **Retirer** la garde `if: github.event_name != 'schedule'` → Trivy tourne désormais sur push, PR, **et** cron Monday 08:00 UTC
- **Élargir** la gate à `HIGH,CRITICAL` (tout en gardant `ignore-unfixed: true` pour ne pas bloquer sur des CVEs sans fix amont)
- **Ajouter** une étape SARIF (`format: sarif`, sévérité `MEDIUM,HIGH,CRITICAL`) + upload via `github/codeql-action/upload-sarif@v3` avec `security-events: write` ; le `if: always()` garantit que les findings atteignent le Security tab même quand la gate fail

## Plan de test

- [ ] CI verte sur ce PR (gate Trivy passe ou identifie de vrais HIGH+CRITICAL légitimes à corriger ensuite)
- [ ] Vérifier que l'onglet **Security → Code scanning** de la repo affiche `trivy-container` après merge
- [ ] Confirmer que le run hebdo (Monday 08:00 UTC) inclut bien Trivy via `gh run list --workflow=security.yml --event=schedule`

## Notes

- `permissions: security-events: write` est ajouté au job (requis par `upload-sarif`)
- Si la gate fail légitimement sur ce PR (vraies HIGH/CRITICAL non vues jusque-là à cause du seuil CRITICAL only), on traitera dans un PR follow-up — c'est précisément ce que ce hardening doit révéler

🤖 Generated with [Claude Code](https://claude.com/claude-code)