### PR TITLE
fix(ci): skip deploy gracefully when GCP secrets are missing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,11 +29,63 @@ env:
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────────
+  # Preflight — verify GCP secrets are configured before attempting deploy.
+  # Without this, every push fails red on auth (the workflow has no way to
+  # tell that the repo hasn't been bootstrapped yet). Skipping gracefully
+  # also keeps the run history clean for forks that legitimately don't deploy.
+  # ─────────────────────────────────────────────────────────────────────────
+  preflight:
+    name: Preflight (deploy secrets check)
+    runs-on: ubuntu-latest
+    outputs:
+      ready: ${{ steps.check.outputs.ready }}
+    steps:
+      - name: Verify deploy secrets are configured
+        id: check
+        env:
+          # Secrets injected via env so we never interpolate them directly in
+          # the shell — values are masked but env-passing is the safe pattern.
+          WIF_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+        run: |
+          if [ -z "$WIF_PROVIDER" ] || [ -z "$SERVICE_ACCOUNT" ] || [ -z "$PROJECT_ID" ]; then
+            {
+              echo "## ⚠️ Deploy skipped — GCP secrets not configured"
+              echo ""
+              echo "This repository has not yet been bootstrapped for Cloud Run deployment."
+              echo ""
+              echo "**Required secrets** (all three must be set at the repo level):"
+              echo "- \`GCP_WORKLOAD_IDENTITY_PROVIDER\`"
+              echo "- \`GCP_SERVICE_ACCOUNT\`"
+              echo "- \`GCP_PROJECT_ID\`"
+              echo ""
+              echo "Optional but needed by Terraform apply / smoke tests:"
+              echo "- \`GEMINI_API_KEY\`"
+              echo "- \`API_KEYS\` (JSON array)"
+              echo ""
+              echo "**Bootstrap steps:**"
+              echo "1. Run \`infra/scripts/bootstrap.sh\` (creates the GCP project, billing link, GCS tfstate bucket)"
+              echo "2. Run \`terraform apply\` from \`infra/terraform/\` once (provisions WIF pool, service accounts, Artifact Registry, Secret Manager)"
+              echo "3. Add the secrets via \`gh secret set GCP_WORKLOAD_IDENTITY_PROVIDER\` (etc.)"
+              echo ""
+              echo "See \`CONTRIBUTING.md\` for the full setup guide."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::Deploy skipped — GCP secrets missing. See job summary for the bootstrap procedure."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Deploy secrets present — proceeding to build & deploy."
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ─────────────────────────────────────────────────────────────────────────
   # Build & Push Docker image to Artifact Registry
   # ─────────────────────────────────────────────────────────────────────────
   build-and-push:
     name: Build & Push
     runs-on: ubuntu-latest
+    needs: preflight
+    if: needs.preflight.outputs.ready == 'true'
 
     permissions:
       contents: read
@@ -89,7 +141,8 @@ jobs:
   deploy:
     name: Terraform Apply + Deploy
     runs-on: ubuntu-latest
-    needs: build-and-push
+    needs: [preflight, build-and-push]
+    if: needs.preflight.outputs.ready == 'true'
     environment: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && 'prod' || 'dev' }}
 
     permissions:
@@ -149,7 +202,8 @@ jobs:
   smoke-test:
     name: Smoke Tests
     runs-on: ubuntu-latest
-    needs: deploy
+    needs: [preflight, deploy]
+    if: needs.preflight.outputs.ready == 'true'
 
     permissions:
       contents: read


### PR DESCRIPTION
## Contexte

Le workflow `Deploy to Cloud Run` a échoué **6 fois sur 6** depuis son introduction le 2026-05-09 17:15 (PR #30). L'audit du programme v2.0 a flaggé ces fails à diagnostiquer (T0-2).

## Diagnostic

Lecture des logs du dernier fail (`gh run view 25625092774 --log-failed`) :

\`\`\`
##[error]google-github-actions/auth failed with: the GitHub Action workflow
must specify exactly one of "workload_identity_provider" or "credentials_json"!
If you are specifying input values via GitHub secrets, ensure the secret is
being injected into the environment.
\`\`\`

Vérification de l'état des secrets côté repo :

\`\`\`
$ gh api repos/Al-khali/shooting_model_basketball/actions/secrets
{ "total_count": 0, "secrets": [] }
\`\`\`

**Aucun secret n'est configuré.** Le workflow attend `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`, `GCP_PROJECT_ID` (+ `GEMINI_API_KEY`, `API_KEYS`). Avec les valeurs vides, l'action `google-github-actions/auth@v2` rejette le call.

C'est un **gap d'amorçage** (l'infra GCP / Workload Identity n'a jamais été provisionnée — `infra/scripts/bootstrap.sh` puis `terraform apply` doivent être exécutés une fois avec un compte GCP, ce que CI ne peut pas faire). Pas un défaut du workflow.

## Fix

Plutôt que laisser le workflow planter rouge à chaque push, on l'arrête proprement quand les secrets manquent :

- Nouveau job **`preflight`** qui vérifie la présence des 3 secrets requis via `env:` (pattern safe — jamais interpolés directement dans le shell)
- Sortie `ready=true|false` exposée comme job output
- `build-and-push`, `deploy` et `smoke-test` gagnent `needs: preflight` + `if: needs.preflight.outputs.ready == 'true'`
- Quand secrets absents : job summary détaillé avec les étapes bootstrap, `::warning::` annotation, mais workflow reste vert
- Quand secrets configurés : deploy procède inchangé

## Plan de test

- [x] CI verte (sans secrets configurés, le workflow doit succeed avec preflight ⏭️ skip sur build/deploy/smoke)
- [ ] Une fois bootstrap fait + secrets ajoutés : prochain push doit déclencher le deploy normal

## Bonus

Le job summary listera les steps bootstrap pour tout fork ou contributeur qui forke sans setup GCP — UX clean au lieu de rouge.

## Hors scope (follow-up)

- Le step \`Auth check (valid key)\` ligne 182 utilise \`echo '\${{ secrets.API_KEYS }}'\` (single-quoted dans une string interpolée) — pas une vulnérabilité actuelle car \`API_KEYS\` est contrôlé par le maintainer, mais à durcir avec \`env:\` aussi
- T0-3 (error handling + VLM resilience) reste ouvert dans Track 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)